### PR TITLE
Improved tmux 1.5 integration; no more window renaming

### DIFF
--- a/autoload/screen.vim
+++ b/autoload/screen.vim
@@ -1064,7 +1064,7 @@ function! s:screenTmux.focusPane(pane) dict
   " If this is a unique paneid, it may be in a different window
   if a:pane =~# '\v^\%\d+$'
     " tmux 1.5: list-{panes,windows} gain `-a` flag
-    let result = self.exec('list-panes -a | grep ' . a:pane)
+    let result = self.exec('list-panes -a | grep "' . a:pane . '\([^0-9]\|$\)"')
     if v:shell_error | return result | endif
 
     " `list-panes -a` returns session:window:pane

--- a/autoload/screen.vim
+++ b/autoload/screen.vim
@@ -963,14 +963,14 @@ endfunction " }}}
 
 function s:screenTmux.openRegion(cmd) dict " {{{
   let orient = s:orientation == 'vertical' ? '-h ' : ''
-  let focus = g:ScreenShellInitialFocus == 'shell' ? 0 : self.activePane()
+  let focus = g:ScreenShellInitialFocus == 'shell' ? '' : self.activePane()
 
   let result = self.exec('split ' .  orient . '-l ' . s:GetSize())
   if v:shell_error | return result | endif
 
   let g:ScreenShellTmuxPane = self.activePane()
 
-  if focus
+  if !empty(focus)
     let result = self.focusPane(focus)
   endif
 

--- a/autoload/screen.vim
+++ b/autoload/screen.vim
@@ -922,18 +922,6 @@ function s:screenTmux.isValid() dict " {{{
   return 1
 endfunction " }}}
 
-function s:screenTmux.activePane() dict "{{{
-  " tmux 1.4: (active) label for current pane
-  " tmux 1.5: Unique %paneid for every pane
-  let line = self.exec('list-panes | grep "(active)$"')
-  let paneid = matchstr(line, '\v\%\d+ \(active\)')
-  if !empty(paneid)
-    return matchstr(paneid, '\v^\%\d+')
-  else
-    return matchstr(line, '\v^\d+')
-  endif
-endfunction " }}}
-
 function s:screenTmux.attachSession(session) dict " {{{
   " TODO: currently unable to implement this since we use -S which creates a
   " new server, which a tmux list-sessions wouldn't be able to talk to.  As
@@ -968,22 +956,23 @@ function s:screenTmux.newTerminalResume() dict " {{{
 endfunction " }}}
 
 function s:screenTmux.newWindow(focus) dict " {{{
-  let result = self.exec('new-window -n ' . g:ScreenShellWindow . (a:focus ? '' : ' -d'))
+  let result = self.exec('new-window ' . (a:focus ? '' : ' -d'))
   let g:ScreenShellTmuxPane = self.activePane()
   return result
 endfunction " }}}
 
 function s:screenTmux.openRegion(cmd) dict " {{{
   let orient = s:orientation == 'vertical' ? '-h ' : ''
-  let focus = g:ScreenShellInitialFocus == 'shell' ? '' : (' ; select-pane -t ' . self.activePane())
+  let focus = g:ScreenShellInitialFocus == 'shell' ? 0 : self.activePane()
 
   let result = self.exec('split ' .  orient . '-l ' . s:GetSize())
   if v:shell_error | return result | endif
 
   let g:ScreenShellTmuxPane = self.activePane()
 
-  let result = self.exec('rename-window ' . g:ScreenShellWindow . focus)
-  if v:shell_error | return result | endif
+  if focus
+    let result = self.focusPane(focus)
+  endif
 
   if !v:shell_error && a:cmd != ''
     let result = self.send(a:cmd)
@@ -991,8 +980,10 @@ function s:screenTmux.openRegion(cmd) dict " {{{
   endif
 endfunction " }}}
 
-function s:screenTmux.setTitle() dict " {{{
-  return self.exec('rename-window ' . g:ScreenShellWindow)
+" s:screenTmux.setTitle() {{{
+" NOP; we are no longer relying on Tmux window titles
+function s:screenTmux.setTitle() dict
+  return 1
 endfunction " }}}
 
 function s:screenTmux.send(value) dict " {{{
@@ -1010,7 +1001,7 @@ function s:screenTmux.send(value) dict " {{{
       \ 'paste-buffer', tmp
       \ ))
     if exists('g:ScreenShellWindow') && !g:ScreenShellExternal
-      call self.exec('select-pane -t ' . vimpane)
+      let result = self.focusPane(vimpane)
     endif
   finally
     call delete(tmp)
@@ -1019,39 +1010,7 @@ function s:screenTmux.send(value) dict " {{{
 endfunction " }}}
 
 function s:screenTmux.focus() dict " {{{
-  if !exists('g:ScreenShellWindow')
-    return
-  endif
-
-  let result = self.exec('list-windows')
-  if v:shell_error
-    return result
-  endif
-
-  let windows = filter(
-    \ split(result, "\n"),
-    \ 'v:val =~ "^\\s*\\d\\+:\\s\\+' . g:ScreenShellWindow . '"')
-  if len(windows)
-    let window = substitute(windows[0], '^\s*\(\d\+\):.*', '\1', '')
-    let result = self.exec('select-window -t:' . window)
-    if v:shell_error
-      return result
-    endif
-  endif
-
-  if !g:ScreenShellExternal
-    let panes = []
-    let result = self.exec('list-panes')
-    let panes = filter(
-      \ split(result, "\n"),
-      \ 'v:val =~ " ' . g:ScreenShellTmuxPane . '\\>"')
-    if len(panes)
-      let result = self.exec('select-pane -t ' . g:ScreenShellTmuxPane)
-    else
-      return 0
-    endif
-  endif
-  return result
+  return self.focusPane(g:ScreenShellTmuxPane)
 endfunction " }}}
 
 function s:screenTmux.quit() dict " {{{
@@ -1081,6 +1040,48 @@ function s:screenTmux.exec(cmd) dict " {{{
   endif
 
   return system(tmux . escape(cmd, ';'))
+endfunction " }}}
+
+function s:screenTmux.activePane() dict "{{{
+  " tmux 1.5: Unique %paneid for every pane
+  let line = self.exec('list-panes | grep "(active)$"')
+  let paneid = matchlist(line, '\v(\%\d+) \(active\)')
+  if empty(paneid)
+    return matchstr(line, '\v^\d+')
+  else
+    return paneid[1]
+  endif
+endfunction " }}}
+
+" s:screenTmux.focusPane() {{{
+" Focus a tmux pane. If a unique pane id is given (e.g. %1), will attempt to
+" select-window to the proper window before select-pane.
+function! s:screenTmux.focusPane(pane) dict
+  if !exists('g:ScreenShellWindow')
+    return
+  endif
+
+  " If this is a unique paneid, it may be in a different window
+  if a:pane =~# '\v^\%\d+$'
+    " tmux 1.5: list-{panes,windows} gain `-a` flag
+    let result = self.exec('list-panes -a | grep ' . a:pane)
+    if v:shell_error | return result | endif
+
+    " `list-panes -a` returns session:window:pane
+    let winpos = matchlist(result, '\v^\d+:(\d+)')
+    if !empty(winpos)
+      " Checking to see if we're in the same window as the target pane would
+      " require a call to list-windows, so we just relax and forget about it.
+      let result = self.exec('select-window -t ' . winpos[1])
+      if v:shell_error | return result | endif
+    endif
+  endif
+
+  if !g:ScreenShellExternal
+    let result = self.exec('select-pane -t ' . a:pane)
+  endif
+
+  return result
 endfunction " }}}
 
 let s:screenConque = {}


### PR DESCRIPTION
Hello again,

Since I've been using screen.vim daily for Clojure coding in the past
weeks, I decided to implement a solution for the tmux window-switching
problem that does not involve setting the window titles.

Quick testing shows that sending from vim -> shell works no matter where
vim or the shell is located, and continues to work if you move both of
them to new locations. I don't use MacVim regularly, but the external
Terminal.app integration also seems to work quite well.

The patch header is below, but I should mention here that the
window-switching does not work in tmux 1.4 and below. It would be easy
to re-add the window-renaming solution for older tmux versions if it's
important to you (so please let me know). However, older tmux versions
still work if the user is careful not switch windows or re-arrange the
shell pane.

Cheers,
Sung

---

Currently, screen.vim uses a magic window title to determine which
window contains the shell pane. This is fragile, mildly annoying, and
also not necessary in Tmux 1.5 (released July 2011).

`tmux list-panes` gained an `-a` flag in the latest version, which lists
all windows along with their unique pane ids. This list can be grepped
to determine the window index of a pane if the unique pane id is known.

First we remove or noop all instances in which we would have set a tmux
window title. Then, we extract and consolidate all calls to select-pane
or select-window into a new method s:screenTmux:focusPane() [1], which
implements the new behavior.

This commit breaks compatibility with tmux 1.4.

[1]: I did not overload s:screenTmux:focus(), because that would have
     violated the arity parity with s:screenGnuScreen:focus()
