### PR TITLE
IPythonVertical support

### DIFF
--- a/autoload/screen.vim
+++ b/autoload/screen.vim
@@ -691,6 +691,16 @@ function! screen#IPython() " {{{
   ScreenShell /usr/bin/ipython
 endfunction " }}}
 
+function! screen#IPythonVertical() " {{{
+  let g:ScreenShellSendPrefixOld = g:ScreenShellSendPrefix
+  let g:ScreenShellSendSuffixOld = g:ScreenShellSendSuffix
+  let g:ScreenShellSendPrefix = '%cpaste'
+  let g:ScreenShellSendSuffix = '--'
+  let g:ScreenShellSendVarsRestore = 1
+
+  ScreenShellVertical /usr/bin/ipython
+endfunction " }}}
+
 function! screen#CommandCompleteScreenSessions(argLead, cmdLine, cursorPos) " {{{
   let cmdLine = strpart(a:cmdLine, 0, a:cursorPos)
   let cmdTail = strpart(a:cmdLine, a:cursorPos)

--- a/plugin/screen.vim
+++ b/plugin/screen.vim
@@ -161,6 +161,11 @@ function! ScreenShellCommands() " {{{
   if !screen#CmdDefined(':IPython')
     command IPython :call screen#IPython()
   endif
+
+  " TODO: add to the documentation
+  if !screen#CmdDefined(':IPythonVertical')
+    command IPythonVertical :call screen#IPythonVertical()
+  endif
 endfunction " }}}
 
 call ScreenShellCommands()


### PR DESCRIPTION
I have added an `IPythonVertical` command as I couldn't find an easy way to create vertical ipython panes (I realized when I first run `ScreenShellVertical` and close it afterwards with `ScreenQuit` and then start ipython with `IPython` it opens up in vertical but I'm not sure if that's intended or not). We can add something to the documentation if you decide to include.
