### PR TITLE
Added ipython3 support

### DIFF
--- a/autoload/screen.vim
+++ b/autoload/screen.vim
@@ -690,7 +690,12 @@ function! screen#IPython(...) " {{{
   let g:ScreenShellSendSuffix = '--'
   let g:ScreenShellSendVarsRestore = 1
 
-  exec 'ScreenShell' . bang . ' ipython'
+  if g:ScreenIPython3 == 1
+    exec 'ScreenShell' . bang . ' ipython3'
+  else
+    exec 'ScreenShell' . bang . ' ipython'
+  endif
+
 endfunction " }}}
 
 function! screen#CommandCompleteScreenSessions(argLead, cmdLine, cursorPos) " {{{

--- a/doc/screen.txt
+++ b/doc/screen.txt
@@ -161,6 +161,9 @@ Below is a comprehensive list of the commands which screen.vim provides:
   of setting |g:ScreenShellSendPrefix| and |g:ScreenShellSendSuffix| properly
   to handle ipython's auto indent support.
 
+  To use IPython3 instead of IPython2 by default, set g:ScreenIPython3 = 1 in
+  your .vimrc.
+
 :IPython!                        *screen-ipython-vertical* *:IPython!*
   Note: unavailable in gvim or if you are using gnu screen without
         |g:ScreenShellGnuScreenVerticalSupport| set.

--- a/plugin/screen.vim
+++ b/plugin/screen.vim
@@ -132,6 +132,11 @@ set cpo&vim
     let g:ScreenShellSendSuffix = ''
   endif
 
+  " Check if user has requested iPython3, and if not, disable that option.
+  if !exists('g:ScreenIPython3')
+    let g:ScreenIPython3 = 0
+  endif
+
 " }}}
 
 " Autocmds {{{


### PR DESCRIPTION
I duplicated the IPython functions in autoload/screen.vim and plugin/screen.vim to include an 'IPython3' function that works identically to the :IPython function but starts ipython3 instead. I can confirm the :ScreenSend works as expected.
